### PR TITLE
tests: associate to the correct package

### DIFF
--- a/splitmix64/test/crusher/dune
+++ b/splitmix64/test/crusher/dune
@@ -1,3 +1,4 @@
 (tests
  (names crusher)
+ (package xoshiro)
  (libraries crusher xoshiro.splitmix64.pure))

--- a/xoshiro256plusplus/test/crusher/dune
+++ b/xoshiro256plusplus/test/crusher/dune
@@ -1,3 +1,4 @@
 (tests
  (names crusher)
+ (package xoshiro)
  (libraries crusher xoshiro.256++.pure))

--- a/xoshiro256plusplus/test/same-bits-ll/dune
+++ b/xoshiro256plusplus/test/same-bits-ll/dune
@@ -1,4 +1,4 @@
-(executable
- (name sameBitsLL)
- (libraries
-  xoshiro.256++.pure xoshiro.256++.bindings))
+(tests
+ (names sameBitsLL)
+ (package xoshiro)
+ (libraries xoshiro.256++.pure xoshiro.256++.bindings))

--- a/xoshiro256plusplus/test/same-bits/dune
+++ b/xoshiro256plusplus/test/same-bits/dune
@@ -1,5 +1,4 @@
 (tests
  (names sameBits)
- (libraries
-  sameBits
-  xoshiro.256++.pure xoshiro.256++.bindings))
+ (package xoshiro)
+ (libraries sameBits xoshiro.256++.pure xoshiro.256++.bindings))


### PR DESCRIPTION
This should fix the issue you are facing on https://github.com/ocaml/opam-repository/pull/18956
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>